### PR TITLE
Services VM out -  K8's now deploys instead 8.5.23

### DIFF
--- a/provision-scripts/cloud-formation/role_based_access_monitored_account_template.yml
+++ b/provision-scripts/cloud-formation/role_based_access_monitored_account_template.yml
@@ -1,0 +1,166 @@
+# Copyright 2022 Dynatrace LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Role-based access for Managed and SaaS deployments with 
+  Environment ActiveGate
+Parameters:
+  ActiveGateAccountID:
+    Type: String
+    Description: The ID of the account hosting the ActiveGate
+      instance
+  ActiveGateRoleName:
+    Type: String
+    Description: IAM role name for the account hosting the ActiveGate for 
+      monitoring. This must be the same name as the ActiveGateRoleName parameter
+      used in the template for the account hosting the ActiveGate.
+    Default: Dynatrace_ActiveGate_role
+  ExternalID:
+    Type: String
+    Description: External ID, copied from Settings > Cloud and virtualization > AWS
+      in Dynatrace
+  RoleName:
+    Type: String
+    Description: IAM role name that Dynatrace should use to get monitoring data.
+      This must be the same name as the MonitoringRoleName parameter
+      used in the template for the account hosting the ActiveGate.
+    Default: Dynatrace_monitoring_role
+  PolicyName:
+    Type: String
+    Description: IAM policy name attached to the role
+    Default: Dynatrace_monitoring_policy
+Resources:
+  MonitoringPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Ref 'PolicyName'
+      Description: Dynatrace Monitoring Policy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: VisualEditor0
+            Effect: Allow
+            Action:
+              - acm-pca:ListCertificateAuthorities
+              - apigateway:GET
+              - apprunner:ListServices
+              - appstream:DescribeFleets
+              - appsync:ListGraphqlApis
+              - athena:ListWorkGroups
+              - autoscaling:DescribeAutoScalingGroups
+              - cloudformation:ListStackResources
+              - cloudfront:ListDistributions
+              - cloudhsm:DescribeClusters
+              - cloudsearch:DescribeDomains
+              - cloudwatch:GetMetricData
+              - cloudwatch:GetMetricStatistics
+              - cloudwatch:ListMetrics
+              - codebuild:ListProjects
+              - datasync:ListTasks
+              - dax:DescribeClusters
+              - directconnect:DescribeConnections
+              - dms:DescribeReplicationInstances
+              - dynamodb:ListTables
+              - dynamodb:ListTagsOfResource
+              - ec2:DescribeAvailabilityZones
+              - ec2:DescribeInstances
+              - ec2:DescribeNatGateways
+              - ec2:DescribeSpotFleetRequests
+              - ec2:DescribeTransitGateways
+              - ec2:DescribeVolumes
+              - ec2:DescribeVpnConnections
+              - ecs:ListClusters
+              - eks:ListClusters
+              - elasticache:DescribeCacheClusters
+              - elasticbeanstalk:DescribeEnvironmentResources
+              - elasticbeanstalk:DescribeEnvironments
+              - elasticfilesystem:DescribeFileSystems
+              - elasticloadbalancing:DescribeInstanceHealth
+              - elasticloadbalancing:DescribeListeners
+              - elasticloadbalancing:DescribeLoadBalancers
+              - elasticloadbalancing:DescribeRules
+              - elasticloadbalancing:DescribeTags
+              - elasticloadbalancing:DescribeTargetHealth
+              - elasticmapreduce:ListClusters
+              - elastictranscoder:ListPipelines
+              - es:ListDomainNames
+              - events:ListEventBuses
+              - firehose:ListDeliveryStreams
+              - fsx:DescribeFileSystems
+              - gamelift:ListFleets
+              - glue:GetJobs
+              - inspector:ListAssessmentTemplates
+              - kafka:ListClusters
+              - kinesis:ListStreams
+              - kinesisanalytics:ListApplications
+              - kinesisvideo:ListStreams
+              - lambda:ListFunctions
+              - lambda:ListTags
+              - lex:GetBots
+              - logs:DescribeLogGroups
+              - mediaconnect:ListFlows
+              - mediaconvert:DescribeEndpoints
+              - mediapackage-vod:ListPackagingConfigurations
+              - mediapackage:ListChannels
+              - mediatailor:ListPlaybackConfigurations
+              - opsworks:DescribeStacks
+              - qldb:ListLedgers
+              - rds:DescribeDBClusters
+              - rds:DescribeDBInstances
+              - rds:DescribeEvents
+              - rds:ListTagsForResource
+              - redshift:DescribeClusters
+              - robomaker:ListSimulationJobs
+              - route53:ListHostedZones
+              - route53resolver:ListResolverEndpoints
+              - s3:ListAllMyBuckets
+              - sagemaker:ListEndpoints
+              - sns:ListTopics
+              - sqs:ListQueues
+              - storagegateway:ListGateways
+              - sts:GetCallerIdentity
+              - swf:ListDomains
+              - tag:GetResources
+              - tag:GetTagKeys
+              - transfer:ListServers
+              - workmail:ListOrganizations
+              - workspaces:DescribeWorkspaces
+            Resource: '*'
+  MonitoringRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref 'RoleName'
+      Description: Dynatrace Monitoring Role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Sub 'arn:aws:iam::${ActiveGateAccountID}:role/${ActiveGateRoleName}'
+                - '509560245411' # Dynatrace monitoring account ID
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref 'ExternalID'
+      Path: /
+      ManagedPolicyArns:
+        - !Ref 'MonitoringPolicy'
+Outputs:
+  RoleName:
+    Description: IAM role that Dynatrace should use to get monitoring data
+    Value: !Ref 'RoleName'
+  AccountID:
+    Description: Your Amazon account ID
+    Value: !Ref 'AWS::AccountId'

--- a/provision-scripts/cloud-formation/workshopActiveGate-createrole.yaml
+++ b/provision-scripts/cloud-formation/workshopActiveGate-createrole.yaml
@@ -1,0 +1,221 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS CloudFormation Template for the AWS Modernization workshop with Dynatrace.
+  You will be billed for the AWS resources used if you create a stack from this template.
+Parameters:
+  DynatraceBaseURL:
+    Description: Your Dynatrace Base URL (example https://ABC.live.dynatrace.com)
+    Type: String
+  DynatracePaasToken:
+    Description: Your Dynatrace PaaS token
+    Type: String
+  KeyPairName:
+    Description: KeyPair name for the EC2 instance
+    Type: String
+    Default: ee-default-keypair
+  ResourcePrefix:
+    Description: Optional value to prefix resource names
+    Type: String
+  InstanceType:
+    Description: EC2 instance type
+    Type: String
+    Default: "m5.xlarge"
+  AvailabilityZone:
+    Description: Subnet AvailabilityZone
+    Type: String
+  ActiveGateRoleName:
+    Type: String
+    Description: IAM role name for the account hosting the ActiveGate for
+      monitoring. This must be the same name as the ActiveGateRoleName parameter 
+      used in the template for the monitored account.
+    Default: Dynatrace_ActiveGate_role
+  AssumePolicyName:
+    Type: String
+    Description: IAM policy name attached to the role for the account hosting the
+      ActiveGate
+    Default: Dynatrace_assume_policy
+  MonitoringRoleName:
+    Type: String
+    Description: IAM role name that Dynatrace should use to get monitoring data. This
+      must be the same name as the RoleName parameter used in the template for the 
+      monitored account.
+    Default: Dynatrace_monitoring_role
+  MonitoredAccountID:
+    Type: String
+    Description: ID of the account that Dynatrace should monitor
+Conditions:
+  HasResourcePrefix: !Not [!Equals [!Ref ResourcePrefix, '']]
+Mappings:
+  RegionMap: 
+    us-east-1: 
+      AMI: ami-09e67e426f25ce0d7
+    us-east-2: 
+      AMI: ami-00399ec92321828f5
+    us-west-1:
+      AMI: ami-0d382e80be7ffdae5
+    us-west-2: 
+      AMI: ami-03d5c68bab01f3496
+    ap-southeast-1:
+      AMI: ami-0d058fe428540cd89
+    ap-southeast-2:
+      AMI: ami-0567f647e75c7bc05
+    eu-west-1:
+      AMI: ami-0a8e758f5e873d1c1
+    eu-west-2:
+      AMI: ami-0194c3e07668a7e36
+    eu-west-3:
+      AMI: ami-0f7cd40eac2214b37
+    eu-north-1:
+      AMI: ami-0ff338189efb7ed37
+    eu-central-1:
+      AMI: ami-05f7491af5eef733a
+Resources:
+  DynatraceAssumePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Ref 'AssumePolicyName'
+      Description: Dynatrace Assume Policy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Resource:
+              - !Sub 'arn:aws:iam::${MonitoredAccountID}:role/${MonitoringRoleName}'
+            Action:
+              - sts:AssumeRole
+            Effect: Allow
+  DynatraceActiveGateRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref 'ActiveGateRoleName'
+      Description: Dynatrace ActiveGate Role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Ref 'DynatraceAssumePolicy'
+  DynatraceActiveGateInstanceProfile: 
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      InstanceProfileName: !Ref 'ActiveGateRoleName'
+      Roles: 
+        - Ref: 'DynatraceActiveGateRole'
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/24
+      Tags:
+        - Key: Name
+          Value: !If [HasResourcePrefix, !Sub "${ResourcePrefix}-activegate", activegate]
+  Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref 'VPC'
+      AvailabilityZone: !Ref 'AvailabilityZone'
+      CidrBlock: 10.0.0.0/24
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !If [HasResourcePrefix, !Sub "${ResourcePrefix}-activegate", activegate]
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !If [HasResourcePrefix, !Sub "${ResourcePrefix}-activegate", activegate]
+        - Key: Application
+          Value: !Ref 'AWS::StackId'
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref 'VPC'
+      InternetGatewayId: !Ref 'InternetGateway'
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref 'VPC'
+      Tags:
+        - Key: Name
+          Value: !If [HasResourcePrefix, !Sub "${ResourcePrefix}-activegate", activegate]
+        - Key: Application
+          Value: !Ref 'AWS::StackId'
+  Route:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref 'RouteTable'
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref 'InternetGateway'
+  SubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref 'Subnet'
+      RouteTableId: !Ref 'RouteTable'
+  DTOrdersInstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access
+      VpcId: !Ref 'VPC'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: '0.0.0.0/0'
+  DTOrdersInstance:
+    Type: AWS::EC2::Instance
+    DependsOn: AttachGateway
+    Properties:
+      InstanceType: !Ref 'InstanceType'
+      KeyName: !Ref 'KeyPairName'
+      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      IamInstanceProfile: !Ref DynatraceActiveGateInstanceProfile
+      Tags:
+        - Key: Name
+          Value: !If [HasResourcePrefix, !Sub "${ResourcePrefix}-activegate", activegate]
+        - Key: Purpose
+          Value: dynatrace-modernize-workshop
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeType: gp2
+            VolumeSize: '20'
+            DeleteOnTermination: 'true'
+            Encrypted: 'false'
+      UserData: !Base64
+        Fn::Join:
+          - ''
+          - - "#!/bin/bash\n"
+            - "wget -O Dynatrace-ActiveGate-Linux.sh \""
+            - !Ref DynatraceBaseURL
+            - "/api/v1/deployment/installer/gateway/unix/latest?arch=x86\" --header=\"Authorization: Api-Token "
+            - !Ref DynatracePaasToken  
+            - "\"\n"
+            - "/bin/bash Dynatrace-ActiveGate-Linux.sh\n"
+      NetworkInterfaces:
+        - GroupSet:
+            - !Ref 'DTOrdersInstanceSecurityGroup'
+          AssociatePublicIpAddress: 'true'
+          DeviceIndex: '0'
+          DeleteOnTermination: 'true'
+          SubnetId: !Ref 'Subnet'
+Outputs:
+  InstanceId:
+    Description: InstanceId of the newly created EC2 instance
+    Value: !Ref 'DTOrdersInstance'
+  ActiveGateRoleName:
+    Description: IAM role name for the account hosting the ActiveGate
+    Value: !Ref 'ActiveGateRoleName'
+  ActiveGateAccountID:
+    Description: Your Amazon account ID hosting the ActiveGate
+    Value: !Ref 'AWS::AccountId'
+  MonitoringRoleName:
+    Description: IAM role that Dynatrace should use to get monitoring data
+    Value: !Ref 'MonitoringRoleName'
+  MonitoredAccountID:
+    Description: ID of the account that Dynatrace should monitor
+    Value: !Ref 'MonitoredAccountID'

--- a/provision-scripts/provision-workshop-managed-K8s.sh
+++ b/provision-scripts/provision-workshop-managed-K8s.sh
@@ -92,18 +92,18 @@ create_aws_monolith-vm() {
         ParameterKey=AvailabilityZone,ParameterValue=$AVAILABILITY_ZONE
 }
 
-# create_aws_services-vm() {
+create_aws_services-vm() {
 
-#   echo "Create AWS resource: services-vm"
-#   aws cloudformation create-stack \
-#       --stack-name "services-vm-$(date +%s)" \
-#       --template-body file://cloud-formation/workshopServices.yaml \
-#       --parameters ParameterKey=DynatraceBaseURL,ParameterValue=$DT_BASEURL \
-#         ParameterKey=DynatracePaasToken,ParameterValue=$DT_API_TOKEN \
-#         ParameterKey=ResourcePrefix,ParameterValue="" \
-#         ParameterKey=KeyPairName,ParameterValue=$KEYPAIR_NAME \
-#         ParameterKey=AvailabilityZone,ParameterValue=$AVAILABILITY_ZONE
-# }
+  echo "Create AWS resource: services-vm"
+  aws cloudformation create-stack \
+      --stack-name "services-vm-$(date +%s)" \
+      --template-body file://cloud-formation/workshopServices.yaml \
+      --parameters ParameterKey=DynatraceBaseURL,ParameterValue=$DT_BASEURL \
+        ParameterKey=DynatracePaasToken,ParameterValue=$DT_API_TOKEN \
+        ParameterKey=ResourcePrefix,ParameterValue="" \
+        ParameterKey=KeyPairName,ParameterValue=$KEYPAIR_NAME \
+        ParameterKey=AvailabilityZone,ParameterValue=$AVAILABILITY_ZONE
+}
 
 create_aws_activegate_role-vm() {
 
@@ -176,13 +176,13 @@ case "$SETUP_TYPE" in
     "monolith-vm")
         create_aws_monolith-vm
         ;;
-    # "services-vm") 
-    #     create_aws_services-vm
-    #     ;;
+    "services-vm") 
+        create_aws_services-vm
+        ;;
     *)
         make_creds_file
         create_aws_monolith-vm
-        # create_aws_services-vm
+        create_aws_services-vm
         
         get_aws_acct_id
         get_dt_external_id


### PR DESCRIPTION
Relabled the old provision-managed.sh file to provision-managedOLD.sh

New provision-managed.sh will no longer deploy the Services Vm's for the dockerized services app version.  

1.  Automate:
     a.  Monolith Vms
     b.  Deploy Kubernetes Cluster 1.26
     c.  Create Activegate
     d.  Create Roles and Policies to use for Cloudwatch integration
     